### PR TITLE
Add man page for vodafone-mobile-broadband

### DIFF
--- a/resources/man/vodafone-mobile-broadband.1
+++ b/resources/man/vodafone-mobile-broadband.1
@@ -1,0 +1,37 @@
+.\" This manpage is copyright (C) 2011 Alex Chiang <achiang@canonical.com>
+.\"
+.\" This is free software; you may redistribute it and/or modify
+.\" it under the terms of the GNU General Public License as
+.\" published by the Free Software Foundation; either version 2,
+.\" or (at your option) any later version.
+.\"
+.\" This is distributed in the hope that it will be useful, but
+.\" WITHOUT ANY WARRANTY; without even the implied warranty of
+.\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.\" GNU General Public License for more details.
+.\"
+.\" You should have received a copy of the GNU General Public
+.\" License along with vodafone-mobile-broadband; if not, write
+.\" to the Free Software Foundation, Inc.,
+.\" 02111-1307 USA
+.TH VODAFONE-MOBILE-BROADBAND 1 "Jan. 4, 2012"
+.SH NAME
+vodafone-mobile-broadband \- launch the vodafone-mobile-broadband GUI
+.SH SYNOPSIS
+.B vodafone-mobile-broadband
+.SH DESCRIPTION
+vodafone-mobile-broadband provides a graphical interface to perform
+activities associated with 3G mobile devices and accounts:
+  - turn 3G internet connection on and off
+  - send and receive SMS
+  - manage SIM card PIN
+  - manage SIM card profiles
+  - check account data plan usage
+  - manage contacts (phonebook) stored on SIM card
+  - purchase additional data from carrier (top up)
+
+There are no command line options associated with this program. All other help
+is accessed from within the program itself.
+.SH AUTHOR
+This manual page was written by Alex Chiang <achiang@canonical.com> for the
+Debian project (but may be used by others).


### PR DESCRIPTION
A skeleton man page, which simply points to the in-application help.
Doesn't seem too useful, but debian requires a man page for every
binary.

Signed-off-by: Alex Chiang achiang@canonical.com
