### PR TITLE
vodafone-mobile-broadband.desktop: remove Encoding field

### DIFF
--- a/resources/desktop/vodafone-mobile-broadband.desktop
+++ b/resources/desktop/vodafone-mobile-broadband.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=Vodafone Mobile Broadband
 Exec=vodafone-mobile-broadband
 Terminal=false


### PR DESCRIPTION
Cleans up debian lintian warning:
    I: vodafone-mobile-broadband: desktop-entry-contains-encoding-key

Signed-off-by: Alex Chiang achiang@canonical.com
